### PR TITLE
Update dev libs which include critical or high severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "underscore.string": "^3.2.2"
   },
   "devDependencies": {
-    "jscs": "^2.8.0",
+    "jscs": "^3.0.7",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.4"
+    "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
Updated `jscs` and `mocha`:

```
lambada:~/src/fast-closure-translater:update-libs» npm test

> fast-closure-translater@0.1.0 test /Users/serif/src/fast-closure-translater
> npm run-script lint && mocha test


> fast-closure-translater@0.1.0 lint /Users/serif/src/fast-closure-translater
> jscs *.js lib/*.js && jshint *.js lib/*.js



  ClosureTranslater
    ✓ should translate simple string as expected
    ✓ should translate message with links as expected
    ✓ should translate message with variables as expected
    ✓ should gracefully handle simple string with missing translations


  4 passing (25ms)

lambada:~/src/fast-closure-translater:update-libs» npm run lint

> fast-closure-translater@0.1.0 lint /Users/serif/src/fast-closure-translater
> jscs *.js lib/*.js && jshint *.js lib/*.js
```